### PR TITLE
Update testing infrastructure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - run:
           name: 'Setup virtual env'
           command: |
-            python3 -mvenv /usr/local/share/virtualenvs/tap-ebay
+            uv venv --python=3.9 /usr/local/share/virtualenvs/tap-ebay
             source /usr/local/share/virtualenvs/tap-ebay/bin/activate
             pip install -U 'pip<19.2' 'setuptools<51.0.0'
             pip install .[dev]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester-uv
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - run:
           name: 'Setup virtual env'
           command: |
-            uv venv --python=3.9 /usr/local/share/virtualenvs/tap-ebay
+            uv venv --python 3.9 /usr/local/share/virtualenvs/tap-ebay
             source /usr/local/share/virtualenvs/tap-ebay/bin/activate
             uv pip install -U 'pip<19.2' 'setuptools<51.0.0'
             uv pip install .[dev]
@@ -16,7 +16,7 @@ jobs:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-ebay/bin/activate
-            pylint -d 'arguments-differ,logging-format-interpolation,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-member,no-self-use,too-many-arguments,unused-argument,unused-import,wrong-import-order' tap_ebay
+            pylintd_key -d 'arguments-differ,logging-format-interpolation,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-member,no-self-use,too-many-arguments,unused-argument,unused-import,wrong-import-order' tap_ebay
 workflows:
   version: 2
   commit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,8 @@ jobs:
           command: |
             uv venv --python=3.9 /usr/local/share/virtualenvs/tap-ebay
             source /usr/local/share/virtualenvs/tap-ebay/bin/activate
-            pip install -U 'pip<19.2' 'setuptools<51.0.0'
-            pip install .[dev]
+            uv pip install -U 'pip<19.2' 'setuptools<51.0.0'
+            uv pip install .[dev]
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,11 @@ jobs:
             source /usr/local/share/virtualenvs/tap-ebay/bin/activate
             uv pip install -U 'pip<19.2' 'setuptools<51.0.0'
             uv pip install .[dev]
-
+      - run:
+          name: 'pylint'
+          command: |
+            source /usr/local/share/virtualenvs/tap-ebay/bin/activate
+            pylint -d 'arguments-differ,logging-format-interpolation,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-member,no-self-use,too-many-arguments,unused-argument,unused-import,wrong-import-order' tap_ebay
 workflows:
   version: 2
   commit:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='tap-ebay',
       ],
       extras_require={
         'dev': [
-            'ipdb==0.11',
+            'ipdb==0.13.13',
             'pylint==2.4.4',
         ]
       },


### PR DESCRIPTION
This PR updates the CircleCI config to use `uv` to create and manage virtualenvs and python dependencies